### PR TITLE
Service projects

### DIFF
--- a/teraserver/python/libtera/db/models/TeraService.py
+++ b/teraserver/python/libtera/db/models/TeraService.py
@@ -24,6 +24,7 @@ class TeraService(db.Model, BaseModel):
     service_default_config = db.Column(db.String, nullable=True, default='{}')
 
     service_roles = db.relationship('TeraServiceRole')
+    service_projects = db.relationship('TeraServiceProject')
 
     def __init__(self):
         pass
@@ -50,6 +51,11 @@ class TeraService(db.Model, BaseModel):
             for role in self.service_roles:
                 roles.append(role.to_json())
             json_service['service_roles'] = roles
+            # Add projects for that service
+            service_projects = []
+            for sp in self.service_projects:
+                service_projects.append(sp.to_json())
+            json_service['service_projects'] = service_projects
 
         if not self.service_endpoint_user:
             del json_service['service_endpoint_user']

--- a/teraserver/python/modules/FlaskModule/API/user/UserQueryProjects.py
+++ b/teraserver/python/modules/FlaskModule/API/user/UserQueryProjects.py
@@ -65,9 +65,13 @@ class UserQueryProjects(Resource):
             if queried_user is not None:
                 user_access = DBManager.userAccess(queried_user)
                 projects = user_access.get_accessible_projects()
+        elif args['id_service']:
+            projects = [project.service_project_project
+                        for project in
+                        user_access.query_projects_for_service(args['id_service'], site_id=args['id_site'])]
         elif args['id_site']:
             # If we have a site id, query for projects of that site
-            projects = user_access.query_projects_for_site(site_id=args['id_site'], service_id=args['id_service'])
+            projects = user_access.query_projects_for_site(site_id=args['id_site'])
         elif args['name']:
             projects = [TeraProject.get_project_by_projectname(projectname=args['name'])]
             for project in projects:
@@ -77,9 +81,6 @@ class UserQueryProjects(Resource):
                 if project.id_project not in user_access.get_accessible_projects_ids():
                     # Current user doesn't have access to the requested project
                     projects = []
-        elif args['id_service']:
-            projects = [project.service_project_project
-                        for project in user_access.query_projects_for_service(args['id_service'])]
         else:
             projects = user_access.get_accessible_projects()
 
@@ -197,4 +198,3 @@ class UserQueryProjects(Resource):
             return gettext('Database error'), 500
 
         return '', 200
-

--- a/teraserver/python/modules/FlaskModule/API/user/UserQueryServices.py
+++ b/teraserver/python/modules/FlaskModule/API/user/UserQueryServices.py
@@ -1,5 +1,7 @@
 from flask import jsonify, session, request
 from flask_restx import Resource, reqparse, inputs
+
+from libtera.db.models import TeraServiceProject
 from modules.LoginModule.LoginModule import user_multi_auth
 from modules.FlaskModule.FlaskModule import user_api_ns as api
 from sqlalchemy.exc import InvalidRequestError
@@ -19,6 +21,7 @@ get_parser.add_argument('uuid', type=str, help='Service UUID to query')
 get_parser.add_argument('key', type=str, help='Service Key to query')
 get_parser.add_argument('list', type=inputs.boolean, help='Flag that limits the returned data to minimal information')
 get_parser.add_argument('with_config', type=inputs.boolean, help='Only return services with editable configuration')
+get_parser.add_argument('with_projects', type=inputs.boolean, help='Return services with service projects')
 
 
 # post_parser = reqparse.RequestParser()
@@ -81,6 +84,12 @@ class UserQueryServices(Resource):
                 if args['with_config']:
                     if not service.service_editable_config:
                         continue
+                if args['with_projects']:
+                    # Get all current association for service
+                    current_projects = TeraServiceProject.get_projects_for_service(id_service=service.id_service)
+                    service_projects = []
+                    for project in current_projects:
+                        service_projects.append(project.to_json())
                 service_json = service.to_json(minimal=args['list'])
                 services_list.append(service_json)
 


### PR DESCRIPTION
Added the call to get all ServiceProjects when fetching a Service when adding a new Project. When creating a new ServiceProject, I need to have the existing ServiceProjects or else, each time I try to add a new Project and link it to a Service, it deletes all the other links.
![image](https://user-images.githubusercontent.com/29826021/96037204-81e01780-0e33-11eb-9279-69f9dd082fa5.png)

Also added the possibility to filter projects by site AND by service.
https://localhost:40075/api/user/projects?id_site=1&id_service=4
`[
  {
    "id_project": 13, 
    "id_site": 1, 
    "project_name": "Project Test 1", 
    "project_role": "admin", 
    "site_name": "Default Site"
  }, 
  {
    "id_project": 7, 
    "id_site": 1, 
    "project_name": "Project Test 2", 
    "project_role": "admin", 
    "site_name": "Default Site"
  }, 
  {
    "id_project": 8, 
    "id_site": 1, 
    "project_name": "Project Test 3", 
    "project_role": "admin", 
    "site_name": "Default Site"
  }
]
`