### PR TITLE
Fetch data until the last hour of the last day & order data by date

### DIFF
--- a/teraserver/python/services/BureauActif/libbureauactif/db/DBManagerBureauActifCalendarAccess.py
+++ b/teraserver/python/services/BureauActif/libbureauactif/db/DBManagerBureauActifCalendarAccess.py
@@ -12,7 +12,7 @@ class DBManagerBureauActifCalendarAccess:
 
         num_days = calendar.monthrange(year, month)[1]
         start_date = datetime.date(year, month, 1)
-        end_date = datetime.date(year, month, num_days)
+        end_date = datetime.datetime(year, month, num_days, 23, 59)
 
         calendar_days = BureauActifCalendarDay.get_calendar_day_by_month(start_date, end_date, participant_uuid)
 

--- a/teraserver/python/services/BureauActif/libbureauactif/db/models/BureauActifCalendarDay.py
+++ b/teraserver/python/services/BureauActif/libbureauactif/db/models/BureauActifCalendarDay.py
@@ -33,7 +33,8 @@ class BureauActifCalendarDay(db.Model, BaseModel):
     @staticmethod
     def get_calendar_day_by_month(start_date, end_date, participant_uuid):
         days = BureauActifCalendarDay.query.filter(BureauActifCalendarDay.date.between(start_date, end_date),
-                                                   BureauActifCalendarDay.participant_uuid == participant_uuid).all()
+                                                   BureauActifCalendarDay.participant_uuid == participant_uuid) \
+            .order_by(BureauActifCalendarDay.date).all()
         if days:
             return days
         return None

--- a/teraserver/python/services/BureauActif/libbureauactif/db/models/BureauActifTimelineDay.py
+++ b/teraserver/python/services/BureauActif/libbureauactif/db/models/BureauActifTimelineDay.py
@@ -21,8 +21,9 @@ class BureauActifTimelineDay(db.Model, BaseModel):
 
     @staticmethod
     def get_timeline_data(start_date, end_date, participant_uuid):
-        days = BureauActifTimelineDay.query.filter(BureauActifTimelineDay.name.between(start_date, end_date),
-                                                   BureauActifTimelineDay.participant_uuid == participant_uuid).all()
+        days = BureauActifTimelineDay.query.filter(
+            BureauActifTimelineDay.name.between(func.date(start_date), func.date(end_date)),
+            BureauActifTimelineDay.participant_uuid == participant_uuid).order_by(BureauActifTimelineDay.name).all()
         if days:
             return days
         return None


### PR DESCRIPTION
Order participant data by date

When fetching calendar days and timeline days between two dates, it was only fetching up to last day 00:00. Now goes up to 23:59.