### PR TITLE
When no date in request, fetch last entries from CalendarDays table

### DIFF
--- a/teraserver/python/services/BureauActif/API/QueryCalendarData.py
+++ b/teraserver/python/services/BureauActif/API/QueryCalendarData.py
@@ -37,15 +37,16 @@ class QueryCalendarData(Resource):
         args = parser.parse_args()
 
         calendar_days = []
-        if not args['date']:
-            return 'Missing date argument', 400
-        elif args['date']:
+        if args['uuid']:
+            participant_uuid = args['uuid']
+        else:
+            participant_uuid = current_participant_client.participant_uuid
+
+        if args['date']:
             date = datetime.datetime.strptime(args['date'], '%d-%m-%Y').date()
-            if args['uuid']:
-                participant_uuid = args['uuid']
-            else:
-                participant_uuid = current_participant_client.participant_uuid
             calendar_days = calendar_access.query_calendar_day_by_month(date, participant_uuid)
+        else:
+            calendar_days = calendar_access.query_last_calendar_days(participant_uuid)
 
         try:
             calendar_days_list = []

--- a/teraserver/python/services/BureauActif/libbureauactif/db/DBManagerBureauActifCalendarAccess.py
+++ b/teraserver/python/services/BureauActif/libbureauactif/db/DBManagerBureauActifCalendarAccess.py
@@ -18,6 +18,18 @@ class DBManagerBureauActifCalendarAccess:
 
         return calendar_days
 
-    def query_calendar_data(self, id_calendar_day: int, id_data_type: int):
-        calendar_data = BureauActifCalendarData.get_calendar_data(id_calendar_day, id_data_type)
-        return calendar_data
+    def query_last_calendar_days(self, participant_uuid):
+        last_day = BureauActifCalendarDay.get_last_entry(participant_uuid)
+
+        if last_day is not None:
+            month = last_day.date.month
+            year = last_day.date.year
+
+            num_days = calendar.monthrange(year, month)[1]
+            start_date = datetime.date(year, month, 1)
+            end_date = datetime.datetime(year, month, num_days, 23, 59)
+
+            calendar_days = BureauActifCalendarDay.get_calendar_day_by_month(start_date, end_date, participant_uuid)
+
+            return calendar_days
+        return None

--- a/teraserver/python/services/BureauActif/libbureauactif/db/models/BureauActifCalendarDay.py
+++ b/teraserver/python/services/BureauActif/libbureauactif/db/models/BureauActifCalendarDay.py
@@ -1,4 +1,4 @@
-from sqlalchemy import and_, func
+from sqlalchemy import and_, func, desc
 from services.BureauActif.libbureauactif.db.Base import db, BaseModel
 import datetime
 
@@ -37,6 +37,14 @@ class BureauActifCalendarDay(db.Model, BaseModel):
             .order_by(BureauActifCalendarDay.date).all()
         if days:
             return days
+        return None
+
+    @staticmethod
+    def get_last_entry(participant_uuid):
+        day = BureauActifCalendarDay.query.filter(
+            BureauActifCalendarDay.participant_uuid == participant_uuid).order_by(desc('date')).first()
+        if day:
+            return day
         return None
 
     @staticmethod


### PR DESCRIPTION
When no date in the request `get` for QueryCalendarDays, returns the entries from the month of the last entry in the table.