### PR TITLE
Bureau data processing fixes

### DIFF
--- a/teraserver/python/services/BureauActif/API/QueryRawData.py
+++ b/teraserver/python/services/BureauActif/API/QueryRawData.py
@@ -114,7 +114,7 @@ class QueryRawData(Resource):
             # Format is a dict with:
             # data -> A list of list which each item is a row in the raw data file:
             #          Timestamp, current_height, button_pressed, present, raw_sensor_values
-            # timers -> dict of values for "up_secs" and "down_secs", corresponding to the current Bureau config
+            # timers -> dict of values for "minutes_up" and "minutes_down", corresponding to the current Bureau config
             # config -> dict of values for the "max_height" and the "min_height" of the Bureau
 
             data_process.process_data(raw_data, file_db_entry)

--- a/teraserver/python/services/BureauActif/libbureauactif/db/DBManagerBureauActifDataProcess.py
+++ b/teraserver/python/services/BureauActif/libbureauactif/db/DBManagerBureauActifDataProcess.py
@@ -98,8 +98,7 @@ class DBManagerBureauActifDataProcess:
             else:
                 entries_before_position_change += 1
 
-        first_position_is_seating = self.find_first_position()  # Find first position of the day
-        self.update_expected_data(first_position_is_seating)
+        self.update_expected_data(self.first_position_is_seating())  # Find first position of the day
         self.save_calendar_data()
 
     def get_absent_time(self, current_index):
@@ -213,7 +212,8 @@ class DBManagerBureauActifDataProcess:
         full_cycles = floor(cycles)
         started_cycle = cycles % 1
         started_cycle_seconds = started_cycle * total_timers
-        self.position_changes.expected = (full_cycles * 2) - 1  # First position of the day doesn't count
+        # First position of the day doesn't count
+        self.position_changes.expected = (full_cycles * 2) - 1 if ((full_cycles * 2) - 1) > 0 else 0
         expected_second_standing = full_cycles * seconds_up
         expected_second_seating = full_cycles * seconds_down
 
@@ -300,5 +300,7 @@ class DBManagerBureauActifDataProcess:
         self.timeline_day_entries.append(first_entry)
 
     # Return True if first position of the day was seating
-    def find_first_position(self):
-        return True if self.timeline_day_entries[1].id_timeline_entry_type in [3, 5] else False
+    def first_position_is_seating(self):
+        if len(self.timeline_day_entries) > 1:
+            return True if self.timeline_day_entries[1].id_timeline_entry_type in [3, 5] else False
+        return True

--- a/teraserver/python/services/BureauActif/libbureauactif/db/models/BureauActifCalendarData.py
+++ b/teraserver/python/services/BureauActif/libbureauactif/db/models/BureauActifCalendarData.py
@@ -37,6 +37,7 @@ class BureauActifCalendarData(db.Model, BaseModel):
     def insert(cls, new_data):
         super().insert(new_data)
         db.session.commit()
+        return new_data
 
     @classmethod
     def update(cls, update_id, values):

--- a/teraserver/python/services/BureauActif/tools/sample_data_loader.py
+++ b/teraserver/python/services/BureauActif/tools/sample_data_loader.py
@@ -4,15 +4,15 @@ import csv
 
 def parse_timers_file(fullpath):
     date = 'invalid'
-    values = {'up_secs': 0, 'down_secs': 0}
+    values = {'minutes_up': 0, 'minutes_down': 0}
 
     if 'Timers_' in fullpath and '.txt' in fullpath:
         date = fullpath.split('_')[1].split('.txt')[0]
 
         try:
             with open(fullpath) as file:
-                values['up_secs'] = float(file.readline().strip())
-                values['down_secs'] = float(file.readline().strip())
+                values['minutes_up'] = float(file.readline().strip())
+                values['minutes_down'] = float(file.readline().strip())
         except:
             print('Error reading: ', fullpath)
 
@@ -74,7 +74,7 @@ def load_data_from_path(path):
                 for res in result:
                     if res != 'invalid':
                         file_data[res] = {'data': result[res],
-                                          'timers': {'up_secs': 0, 'down_secs': 0}}
+                                          'timers': {'minutes_up': 0, 'minutes_down': 0}}
 
             # Config file
             if '.txt' in filename:


### PR DESCRIPTION
Renamed `minutes_down` and `minutes_up` to fit the script on the Raspberry Pi
Fixed an out of range error in `first_position_is_seating` causing the CalendarData entries to not be created for that day, resulting in getting an error 500 on the website