### PR TITLE
Bureau data fixes

### DIFF
--- a/teraserver/python/services/BureauActif/API/QueryCalendarData.py
+++ b/teraserver/python/services/BureauActif/API/QueryCalendarData.py
@@ -53,9 +53,11 @@ class QueryCalendarData(Resource):
             if calendar_days is not None:
                 for day in calendar_days:
                     if day is not None:
-                        day_json = day.to_json()
+                        day_json = day.to_json(['timeline'])
 
-                        if day.seating is not None and day.standing is not None and day.positionChanges is not None:
+                        if day.seating is not None and day.standing is not None and day.positionChanges is not None \
+                                and (day.seating.expected + day.standing.expected) < 10 \
+                                and day.timeline is not None and len(day.timeline[0].series) > 1:
                             day_json['seating'] = day.seating.to_json()
                             day_json['standing'] = day.standing.to_json()
                             day_json['positionChanges'] = day.positionChanges.to_json()

--- a/teraserver/python/services/BureauActif/API/QueryCalendarData.py
+++ b/teraserver/python/services/BureauActif/API/QueryCalendarData.py
@@ -55,11 +55,12 @@ class QueryCalendarData(Resource):
                     if day is not None:
                         day_json = day.to_json()
 
-                        day_json['seating'] = day.seating.to_json()
-                        day_json['standing'] = day.standing.to_json()
-                        day_json['positionChanges'] = day.positionChanges.to_json()
+                        if day.seating is not None and day.standing is not None and day.positionChanges is not None:
+                            day_json['seating'] = day.seating.to_json()
+                            day_json['standing'] = day.standing.to_json()
+                            day_json['positionChanges'] = day.positionChanges.to_json()
 
-                        calendar_days_list.append(day_json)
+                            calendar_days_list.append(day_json)
 
             return jsonify(calendar_days_list)
 

--- a/teraserver/python/services/BureauActif/API/QueryTimelineData.py
+++ b/teraserver/python/services/BureauActif/API/QueryTimelineData.py
@@ -55,16 +55,6 @@ class QueryTimelineData(Resource):
                     if day is not None and len(day.series) > 1:
                         day_json = day.to_json()
 
-                        if day.series is not None:
-                            entries = timeline_access.query_timeline_day_entries(day.id_timeline_day)
-                            entries_json = []
-                            for entry in entries:
-                                entry_json = entry.to_json()
-                                entry_type = timeline_access.query_timeline_type_by_id(entry.id_timeline_entry_type)
-                                entry_json['name'] = entry_type.name
-                                entries_json.append(entry_json)
-                            day_json['series'] = entries_json
-
                         timeline_days_list.append(day_json)
 
             return jsonify(timeline_days_list)

--- a/teraserver/python/services/BureauActif/API/QueryTimelineData.py
+++ b/teraserver/python/services/BureauActif/API/QueryTimelineData.py
@@ -52,7 +52,7 @@ class QueryTimelineData(Resource):
             timeline_days_list = []
             if timeline_days is not None:
                 for day in timeline_days:
-                    if day is not None:
+                    if day is not None and len(day.series) > 1:
                         day_json = day.to_json()
 
                         if day.series is not None:

--- a/teraserver/python/services/BureauActif/libbureauactif/db/DBManagerBureauActifCalendarAccess.py
+++ b/teraserver/python/services/BureauActif/libbureauactif/db/DBManagerBureauActifCalendarAccess.py
@@ -1,5 +1,4 @@
 from services.BureauActif.libbureauactif.db.models.BureauActifCalendarDay import BureauActifCalendarDay
-from services.BureauActif.libbureauactif.db.models.BureauActifCalendarData import BureauActifCalendarData
 import datetime
 import calendar
 

--- a/teraserver/python/services/BureauActif/libbureauactif/db/DBManagerBureauActifDataProcess.py
+++ b/teraserver/python/services/BureauActif/libbureauactif/db/DBManagerBureauActifDataProcess.py
@@ -106,7 +106,8 @@ class DBManagerBureauActifDataProcess:
             past_data = self.get_time(current_index - 1)
             current_data = self.get_time(current_index)
             delta = current_data - past_data
-            if delta.seconds > 300:  # Absence is worth showing in timeline only if at least 5 minutes
+            # Absence is worth showing in timeline only if at least 30 seconds (match sensitivity of pi censor)
+            if delta.seconds > 30:
                 delta_in_hour = delta.seconds / 3600
                 return delta_in_hour
         return 0
@@ -177,12 +178,12 @@ class DBManagerBureauActifDataProcess:
 
     def update_seating(self, index, entries_before_position_change):
         delta = self.get_time_difference(index, entries_before_position_change)
-        self.update_last_timeline_entry(delta, 3)
+        self.update_last_timeline_entry(delta, 3, index, entries_before_position_change)
         self.seating.done += delta
 
     def update_standing(self, index, entries_before_position_change):
         delta = self.get_time_difference(index, entries_before_position_change)
-        self.update_last_timeline_entry(delta, 2)
+        self.update_last_timeline_entry(delta, 2, index, entries_before_position_change)
         self.standing.done += delta
 
     def get_time_difference(self, index, entries_count):
@@ -247,18 +248,22 @@ class DBManagerBureauActifDataProcess:
             BureauActifCalendarData.insert(self.seating)
             BureauActifCalendarData.insert(self.standing)
 
-    def update_last_timeline_entry(self, delta, id_type):
+    def update_last_timeline_entry(self, delta, id_type, index, entries_count):
         color_type = self.get_right_timeline_color(id_type)
         if delta > 0:
             last_entry = self.timeline_day_entries[len(self.timeline_day_entries) - 1]
             if last_entry.id_timeline_entry_type == color_type:
                 last_entry.value += delta
+                last_entry.end_time = self.get_time(index - 1)
                 db.session.commit()
             else:
                 if color_type not in [5, 6] and not self.is_first_timeline_entry() \
                         and not self.is_back_from_absence() and not self.is_position_same(color_type):
                     self.position_changes.done += 1  # Count as a position change
-                new_entry = BureauActifTimelineDayEntry.insert(self.create_new_timeline_entry(color_type, delta))
+                start_time = self.get_time(index - entries_count)
+                end_time = self.get_time(index - 1)
+                new_entry = BureauActifTimelineDayEntry.insert(
+                    self.create_new_timeline_entry(color_type, delta, end_time, start_time))
                 self.timeline_day_entries.append(new_entry)
 
     # Returns true if the only entry in the timeline is the starting block
@@ -285,18 +290,20 @@ class DBManagerBureauActifDataProcess:
             return 5  # Supposed to be standing
         return id_type
 
-    def create_new_timeline_entry(self, id_type, delta):
+    def create_new_timeline_entry(self, id_type, delta, end_time, start_time=None):
         entry = BureauActifTimelineDayEntry()
         entry.id_timeline_entry_type = id_type
         entry.value = delta
         entry.id_timeline_day = self.timeline_day.id_timeline_day
+        entry.end_time = end_time
+        entry.start_time = start_time
         return entry
 
     # Add the timeline block from midnight to first entry time to make the relative timeline
     def set_starting_hour(self, date):
         starting_time = date.time()
         time = starting_time.hour + (starting_time.minute / 60)
-        first_entry = BureauActifTimelineDayEntry.insert(self.create_new_timeline_entry(1, time))
+        first_entry = BureauActifTimelineDayEntry.insert(self.create_new_timeline_entry(1, time, date))
         self.timeline_day_entries.append(first_entry)
 
     # Return True if first position of the day was seating

--- a/teraserver/python/services/BureauActif/libbureauactif/db/DBManagerBureauActifDataProcess.py
+++ b/teraserver/python/services/BureauActif/libbureauactif/db/DBManagerBureauActifDataProcess.py
@@ -93,7 +93,7 @@ class DBManagerBureauActifDataProcess:
             if self.is_last_data(index) or was_standing != is_standing or \
                     absent_time != 0 or self.previous_is_config_respected != self.is_config_respected:
                 self.update_position(was_standing, index, entries_before_position_change)
-                self.update_last_timeline_entry(absent_time, 4)
+                self.update_last_timeline_entry(absent_time, 4, index, entries_before_position_change)
                 entries_before_position_change = 0
             else:
                 entries_before_position_change += 1

--- a/teraserver/python/services/BureauActif/libbureauactif/db/DBManagerBureauActifDataProcess.py
+++ b/teraserver/python/services/BureauActif/libbureauactif/db/DBManagerBureauActifDataProcess.py
@@ -1,4 +1,4 @@
-from math import ceil, floor
+from math import floor
 import datetime
 from services.BureauActif.libbureauactif.db.Base import db
 from services.BureauActif.libbureauactif.db.models.BureauActifCalendarDay import BureauActifCalendarDay
@@ -32,10 +32,10 @@ def get_timeline_day(uuid_participant, date):
     return BureauActifTimelineDay.get_timeline_day(uuid_participant, date.date())
 
 
-def create_new_timeline_day(date, uuid_participant):
     timeline_day = BureauActifTimelineDay()
     timeline_day.participant_uuid = uuid_participant
     timeline_day.name = date
+    timeline_day.id_calendar_day = id_calendar_day
     return timeline_day
 
 
@@ -131,7 +131,6 @@ class DBManagerBureauActifDataProcess:
         entry = get_timeline_day(uuid_participant, date)
 
         if entry is None:  # No data for the current day, starting a new one
-            self.timeline_day = BureauActifTimelineDay.insert(create_new_timeline_day(date, uuid_participant))
             self.set_starting_hour(date)  # Add starting block in timeline
         else:  # Data already present for the current day
             self.timeline_day = entry
@@ -254,14 +253,14 @@ class DBManagerBureauActifDataProcess:
             last_entry = self.timeline_day_entries[len(self.timeline_day_entries) - 1]
             if last_entry.id_timeline_entry_type == color_type:
                 last_entry.value += delta
-                last_entry.end_time = self.get_time(index - 1)
+                last_entry.end_time = self.get_time(index)
                 db.session.commit()
             else:
                 if color_type not in [5, 6] and not self.is_first_timeline_entry() \
                         and not self.is_back_from_absence() and not self.is_position_same(color_type):
                     self.position_changes.done += 1  # Count as a position change
                 start_time = self.get_time(index - entries_count)
-                end_time = self.get_time(index - 1)
+                end_time = self.get_time(index)
                 new_entry = BureauActifTimelineDayEntry.insert(
                     self.create_new_timeline_entry(color_type, delta, end_time, start_time))
                 self.timeline_day_entries.append(new_entry)

--- a/teraserver/python/services/BureauActif/libbureauactif/db/DBManagerBureauActifDataProcess.py
+++ b/teraserver/python/services/BureauActif/libbureauactif/db/DBManagerBureauActifDataProcess.py
@@ -32,6 +32,7 @@ def get_timeline_day(uuid_participant, date):
     return BureauActifTimelineDay.get_timeline_day(uuid_participant, date.date())
 
 
+def create_new_timeline_day(date, uuid_participant, id_calendar_day):
     timeline_day = BureauActifTimelineDay()
     timeline_day.participant_uuid = uuid_participant
     timeline_day.name = date
@@ -131,6 +132,8 @@ class DBManagerBureauActifDataProcess:
         entry = get_timeline_day(uuid_participant, date)
 
         if entry is None:  # No data for the current day, starting a new one
+            self.timeline_day = BureauActifTimelineDay.insert(
+                create_new_timeline_day(date, uuid_participant, self.calendar_day.id_calendar_day))
             self.set_starting_hour(date)  # Add starting block in timeline
         else:  # Data already present for the current day
             self.timeline_day = entry

--- a/teraserver/python/services/BureauActif/libbureauactif/db/models/BureauActifCalendarDay.py
+++ b/teraserver/python/services/BureauActif/libbureauactif/db/models/BureauActifCalendarDay.py
@@ -23,6 +23,7 @@ class BureauActifCalendarDay(db.Model, BaseModel):
                                                   "==BureauActifCalendarData.id_calendar_day, "
                                                   "BureauActifCalendarData.id_calendar_data_type==3)",
                                       uselist=False)
+    timeline = db.relationship('BureauActifTimelineDay')
 
     def to_json(self, ignore_fields=None, minimal=False):
         if ignore_fields is None:

--- a/teraserver/python/services/BureauActif/libbureauactif/db/models/BureauActifTimelineDay.py
+++ b/teraserver/python/services/BureauActif/libbureauactif/db/models/BureauActifTimelineDay.py
@@ -8,6 +8,8 @@ class BureauActifTimelineDay(db.Model, BaseModel):
     __tablename__ = "ba_timeline_day"
     id_timeline_day = db.Column(db.Integer, db.Sequence('id_timeline_day_sequence'), primary_key=True,
                                 autoincrement=True)
+    id_calendar_day = db.Column(db.Integer, db.ForeignKey('ba_calendar_day.id_calendar_day', ondelete='cascade'),
+                                nullable=True)
     participant_uuid = db.Column(db.String(36), nullable=True)
     name = db.Column(db.TIMESTAMP(timezone=True), nullable=False)
 
@@ -17,7 +19,17 @@ class BureauActifTimelineDay(db.Model, BaseModel):
         if ignore_fields is None:
             ignore_fields = []
 
-        return super().to_json(ignore_fields=ignore_fields)
+            rval = super().to_json(ignore_fields=ignore_fields)
+
+            entries_json = []
+            for entry in self.series:
+                entry_type = entry.entry_type
+                entry_json = entry.to_json()
+                entry_json['name'] = entry_type.name
+                entries_json.append(entry_json)
+            rval['series'] = entries_json
+
+        return rval
 
     @staticmethod
     def get_timeline_data(start_date, end_date, participant_uuid):
@@ -47,14 +59,17 @@ class BureauActifTimelineDay(db.Model, BaseModel):
     def create_defaults():
         timeline_data = BureauActifTimelineDay()
         timeline_data.name = datetime.datetime.strptime('23-03-2020', '%d-%m-%Y').date()
+        timeline_data.id_calendar_day = 1
         db.session.add(timeline_data)
 
         timeline_data2 = BureauActifTimelineDay()
         timeline_data2.name = datetime.datetime.strptime('24-03-2020', '%d-%m-%Y').date()
+        timeline_data.id_calendar_day = 2
         db.session.add(timeline_data2)
 
         timeline_data3 = BureauActifTimelineDay()
         timeline_data3.name = datetime.datetime.strptime('25-03-2020', '%d-%m-%Y').date()
+        timeline_data.id_calendar_day = 3
         db.session.add(timeline_data3)
 
         db.session.commit()

--- a/teraserver/python/services/BureauActif/libbureauactif/db/models/BureauActifTimelineDayEntry.py
+++ b/teraserver/python/services/BureauActif/libbureauactif/db/models/BureauActifTimelineDayEntry.py
@@ -16,10 +16,12 @@ class BureauActifTimelineDayEntry(db.Model, BaseModel):
     value = db.Column(db.Float, nullable=False)
     start_time = db.Column(db.TIMESTAMP(timezone=True), nullable=True)
     end_time = db.Column(db.TIMESTAMP(timezone=True), nullable=True)
+    entry_type = db.relationship('BureauActifTimelineEntryType')
 
     def to_json(self, ignore_fields=None, minimal=False):
         if ignore_fields is None:
             ignore_fields = []
+        ignore_fields.append('entry_type')
 
         return super().to_json(ignore_fields=ignore_fields)
 

--- a/teraserver/python/services/BureauActif/libbureauactif/db/models/BureauActifTimelineDayEntry.py
+++ b/teraserver/python/services/BureauActif/libbureauactif/db/models/BureauActifTimelineDayEntry.py
@@ -14,8 +14,8 @@ class BureauActifTimelineDayEntry(db.Model, BaseModel):
                                                      ondelete='cascade'),
                                        nullable=True)
     value = db.Column(db.Float, nullable=False)
-
-    # timeline_data_type = db.relationship("BureauActifTimelineEntryType")
+    start_time = db.Column(db.TIMESTAMP(timezone=True), nullable=True)
+    end_time = db.Column(db.TIMESTAMP(timezone=True), nullable=True)
 
     def to_json(self, ignore_fields=None, minimal=False):
         if ignore_fields is None:

--- a/teraserver/python/services/BureauActif/tools/sample_data_importer.py
+++ b/teraserver/python/services/BureauActif/tools/sample_data_importer.py
@@ -9,7 +9,8 @@ from services.BureauActif.tools.sample_data_loader import load_data_from_path
 class Config:
     hostname = 'localhost'
     port = 40075
-    servicename = '/bureau'
+    service_name = '/bureau'
+    data_path = r''
 
     # User endpoints
     user_login_endpoint = '/api/user/login'
@@ -328,7 +329,7 @@ def add_service_to_project(config: Config, id_project: int, s_uuid: str):
 
 def create_session_data(config: Config, token: str, filename: str, data, id_session: int,
                         date: datetime = datetime.now()):
-    url = _make_url(config.hostname, config.port, config.servicename + '/' + config.device_session_data_endpoint) + \
+    url = _make_url(config.hostname, config.port, config.service_name + '/' + config.device_session_data_endpoint) + \
           '?token=' + token
 
     # id_session = int(request.headers['X-Id-Session'])
@@ -355,7 +356,7 @@ def create_session_data(config: Config, token: str, filename: str, data, id_sess
 
 
 def get_bureau_actif_service_uuid(config: Config, token: str) -> str:
-    url = _make_url(config.hostname, config.port, config.servicename + config.service_info_endpoint)
+    url = _make_url(config.hostname, config.port, config.service_name + config.service_info_endpoint)
     params = {'token': token}
     try:
         response = get(url=url, params=params, verify=False)
@@ -375,14 +376,13 @@ def get_bureau_actif_service_uuid(config: Config, token: str) -> str:
 if __name__ == '__main__':
 
     base_config = Config()
-    data_path = r''
 
     # Ignore insecure requests warning
     import urllib3
     urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
     # Get data from files
-    result = load_data_from_path(data_path)
+    result = load_data_from_path(base_config.data_path)
 
     # Login admin
     admin_info = login_user(base_config)
@@ -405,7 +405,7 @@ if __name__ == '__main__':
         add_service_to_project(base_config, project_info['id_project'], service_uuid)
 
     import os
-    participant_name = os.path.split(data_path)[-1]
+    participant_name = os.path.split(base_config.data_path)[-1]
     participant_info = get_participant(base_config, participant_name)
 
     if participant_info:


### PR DESCRIPTION
To maintain accuracy between real data and calculated times for seating/standing/absence, the threshold for absent time was changed to 30 seconds (from 300) to fit with the one from the Pi. So every time a 30 sec is detected, an absent block will appear. 

Added two new properties to Timeline Day Entry : end_time and start_time to add information for a timeline block. 
```
start_time = db.Column(db.TIMESTAMP(timezone=True), nullable=True)
end_time = db.Column(db.TIMESTAMP(timezone=True), nullable=True)
```

If the data for a CalendarDay is None, which was throwing an error and making it impossible de show data for the month, it simply skips the day.