### PR TITLE
Route vue-router / webpack application

### DIFF
--- a/teraserver/python/config/opentera.conf
+++ b/teraserver/python/config/opentera.conf
@@ -535,19 +535,21 @@ location /websocket/8089/ {
 ########################################################################################################################
 location ~ ^/webrtc_teleop/(.*)$ {
 
+    # Here is a tool to help you debug these regular expressions https://regex101.com/
+
     # Match if do not end with index.html or .css or .js
-    rewrite     ^/webrtc_teleop/([0-9]+)/((?!index.html).*(?<!\.css|\.js))$     /teleop/$1/index.html last;
+    rewrite     ^/webrtc_teleop/([0-9]+)/((?!index.html).*(?<!\.css|\.js))$     /signaling_server/$1/index.html last;
 
     # Match if end with js/*.js or css css/*.css
-    rewrite     ^/webrtc_teleop/([0-9]+)/.*((?>js|css)/.*\.(?>css|js))$         /teleop/$1/$2 last;
+    rewrite     ^/webrtc_teleop/([0-9]+)/.*((?>js|css)/.*\.(?>css|js))$         /signaling_server/$1/$2 last;
 
     # Redirection to the proxy
-    rewrite     ^/webrtc_teleop/(.*)$                                           /teleop/$1$is_args$args last;
+    rewrite     ^/webrtc_teleop/(.*)$                                           /signaling_server/$1$is_args$args last;
 
     return 403;
 }
 
-location ~ ^/teleop/(.*)$ {
+location ~ ^/signaling_server/(.*)$ {
     proxy_pass http://127.0.0.1:$1$is_args$args;
     proxy_set_header    X-ExternalPort      $server_port;
     proxy_set_header    X-ExternalHost      $host;

--- a/teraserver/python/config/opentera.conf
+++ b/teraserver/python/config/opentera.conf
@@ -535,20 +535,32 @@ location /websocket/8089/ {
 ########################################################################################################################
 location ~ ^/webrtc_teleop/(.*)$ {
 
+    # Match if do not end with index.html or .css or .js
+    rewrite     ^/webrtc_teleop/([0-9]+)/((?!index.html).*(?<!\.css|\.js))$     /teleop/$1/index.html last;
+
+    # Match if end with js/*.js or css css/*.css
+    rewrite     ^/webrtc_teleop/([0-9]+)/.*((?>js|css)/.*\.(?>css|js))$         /teleop/$1/$2 last;
+
+    # Redirection to the proxy
+    rewrite     ^/webrtc_teleop/(.*)$                                           /teleop/$1$is_args$args last;
+
+    return 403;
+}
+
+location ~ ^/teleop/(.*)$ {
     proxy_pass http://127.0.0.1:$1$is_args$args;
-    proxy_set_header 	X-ExternalPort      $server_port;
-    proxy_set_header 	X-ExternalHost      $host;
-    proxy_set_header   	Host                $host;
-    proxy_set_header   	X-Real-IP           $remote_addr;
-    proxy_set_header   	X-Forwarded-For     $proxy_add_x_forwarded_for;
-    proxy_set_header   	X-Forwarded-Proto   $scheme;
-    proxy_set_header	X-Scheme            $scheme;
-    proxy_set_header 	X-Script-Name       /webrtc_teleop/;
+    proxy_set_header    X-ExternalPort      $server_port;
+    proxy_set_header    X-ExternalHost      $host;
+    proxy_set_header    Host                $host;
+    proxy_set_header    X-Real-IP           $remote_addr;
+    proxy_set_header    X-Forwarded-For     $proxy_add_x_forwarded_for;
+    proxy_set_header    X-Forwarded-Proto   $scheme;
+    proxy_set_header    X-Scheme            $scheme;
+    proxy_set_header    X-Script-Name       /webrtc_teleop/;
 
     # Websocket upgrades
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection "upgrade";
-
 }
 


### PR DESCRIPTION
This pull request allow to route properly a Vue application that uses vue-router.

It might not be the best solution, it look a bit complex for what it does with its regulars expressions, and it is also tightly couple with the following Webpack's build files structure: 
```
dist/
    js/
       app.js
    app/
        app.css
    index.html
```
It may break if we use a different file structure as static web application.

Another and better solution could emerge from this idea. I'm looking for a better way of doing it.